### PR TITLE
Fix missing content length bug

### DIFF
--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2Handler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2Handler.java
@@ -235,7 +235,7 @@ public class AWSV2Handler extends XRayHandler {
         // Obtain the content length from the header map and store it in the subsegment
         Map<String, List<String>> headerMap = responseEvent.getHeaderMap();
         List<String> contentLengthList = headerMap.get(EntityHeaderKeys.HTTP.CONTENT_LENGTH_HEADER);
-        if (contentLengthList.size() > 0) {
+        if (contentLengthList != null && contentLengthList.size() > 0) {
             long contentLength = Long.parseLong(contentLengthList.get(0));
             responseInformation.put(CONTENT_LENGTH_KEY, contentLength);
         }


### PR DESCRIPTION
*Issue #, if available:*
#23

*Description of changes:*
Some requests don't include the content length in the header. Added a null check to ensure that the header item exists. Test added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
