### PR TITLE
Future-proof integration tests & other fixes

### DIFF
--- a/aws-xray-auto-instrumentation-agent-bootstrap/pom.xml
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/pom.xml
@@ -37,7 +37,7 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml</pattern>
-                                    <shadedPattern>software.amazon.disco.agent.jar.fasterxmll</shadedPattern>
+                                    <shadedPattern>software.amazon.disco.agent.jar.fasterxml</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.bytebuddy</pattern>

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/com/amazonaws/xray/agent/XRayInstrumentationAgent.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/com/amazonaws/xray/agent/XRayInstrumentationAgent.java
@@ -37,6 +37,7 @@ public class XRayInstrumentationAgent {
      * DiSCo logger is used to avoid loading Apache logger before it's configured
      */
     private static final Logger log = LogManager.getLogger(XRayInstrumentationAgent.class);
+    private static Class<?> agentRuntimeLoaderClass;
 
     /**
      * The agent is loaded by a -javaagent command line parameter, which will treat 'premain' as its
@@ -92,8 +93,6 @@ public class XRayInstrumentationAgent {
 
     private static AgentRuntimeLoaderInterface getAgentRuntimeLoader(ClassLoader classLoader) throws ClassNotFoundException, IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
         // Iterate through its parents until we find it. If we reach the bootstrap, then we know it doesn't exist.
-
-        Class<?> agentRuntimeLoaderClass;
         ClassLoader currentClassloader = classLoader;
 
         // Use the application classloader if the classloader passed in is null (within the bootstrap)

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/com/amazonaws/xray/agent/XRayInstrumentationAgent.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/com/amazonaws/xray/agent/XRayInstrumentationAgent.java
@@ -1,8 +1,8 @@
 package com.amazonaws.xray.agent;
 
+import software.amazon.disco.agent.DiscoAgentTemplate;
 import software.amazon.disco.agent.awsv1.AWSClientInvokeInterceptor;
 import software.amazon.disco.agent.awsv2.AWSClientBuilderInterceptor;
-import software.amazon.disco.agent.DiscoAgentTemplate;
 import software.amazon.disco.agent.concurrent.ConcurrencySupport;
 import software.amazon.disco.agent.event.EventBus;
 import software.amazon.disco.agent.interception.Installable;
@@ -93,7 +93,7 @@ public class XRayInstrumentationAgent {
     private static AgentRuntimeLoaderInterface getAgentRuntimeLoader(ClassLoader classLoader) throws ClassNotFoundException, IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
         // Iterate through its parents until we find it. If we reach the bootstrap, then we know it doesn't exist.
 
-        Class<?> agentRuntimeLoaderClass = null;
+        Class<?> agentRuntimeLoaderClass;
         ClassLoader currentClassloader = classLoader;
 
         // Use the application classloader if the classloader passed in is null (within the bootstrap)

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/software/amazon/disco/agent/awsv1/AWSClientInvokeInterceptor.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/software/amazon/disco/agent/awsv1/AWSClientInvokeInterceptor.java
@@ -1,11 +1,5 @@
 package software.amazon.disco.agent.awsv1;
 
-import software.amazon.disco.agent.event.EventBus;
-import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
-import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
-import software.amazon.disco.agent.interception.Installable;
-import software.amazon.disco.agent.logging.LogManager;
-import software.amazon.disco.agent.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -16,6 +10,12 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
+import software.amazon.disco.agent.event.EventBus;
+import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
+import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
+import software.amazon.disco.agent.interception.Installable;
+import software.amazon.disco.agent.logging.LogManager;
+import software.amazon.disco.agent.logging.Logger;
 
 import java.util.concurrent.Callable;
 

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/software/amazon/disco/agent/awsv2/executioninterceptor/DiscoExecutionInterceptor.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/main/java/software/amazon/disco/agent/awsv2/executioninterceptor/DiscoExecutionInterceptor.java
@@ -5,8 +5,8 @@ import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.FailedEx
 import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.InterceptorContextAccessor;
 import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.sdkrequest.SdkHttpRequestAccessor;
 import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.sdkrequest.SdkRequestAccessor;
-import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.sdkresponse.SdkResponseAccessor;
 import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.sdkresponse.SdkHttpResponseAccessor;
+import software.amazon.disco.agent.awsv2.executioninterceptor.accessors.sdkresponse.SdkResponseAccessor;
 import software.amazon.disco.agent.event.AwsServiceDownstreamRequestEvent;
 import software.amazon.disco.agent.event.AwsServiceDownstreamRequestEventImpl;
 import software.amazon.disco.agent.event.AwsServiceDownstreamResponseEvent;

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/test/java/com/amazonaws/xray/agent/XRayInstrumentationAgentTest.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/test/java/com/amazonaws/xray/agent/XRayInstrumentationAgentTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.disco.agent.DiscoAgentTemplate;
@@ -18,13 +19,12 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest({XRayInstrumentationAgent.class, AgentRuntimeLoaderInterface.class, DiscoAgentTemplate.class})
 public class XRayInstrumentationAgentTest {
     private static final String GET_AGENT_RUNTIME_METHOD = "getAgentRuntimeLoader";
     private final String serviceName = "ControlPlane";
-    public static final String TRACE_HEADER_KEY = "X-Amzn-Trace-Id";
 
     @Mock
     private Instrumentation instrumentation;

--- a/aws-xray-auto-instrumentation-agent-bootstrap/src/test/java/software/amazon/disco/agent/awsv1/AWSClientInvokeInterceptorTests.java
+++ b/aws-xray-auto-instrumentation-agent-bootstrap/src/test/java/software/amazon/disco/agent/awsv1/AWSClientInvokeInterceptorTests.java
@@ -1,10 +1,5 @@
 package software.amazon.disco.agent.awsv1;
 
-import software.amazon.disco.agent.event.Event;
-import software.amazon.disco.agent.event.EventBus;
-import software.amazon.disco.agent.event.Listener;
-import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
-import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
 import com.amazonaws.AmazonWebServiceClient;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.DefaultRequest;
@@ -23,6 +18,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import software.amazon.disco.agent.event.Event;
+import software.amazon.disco.agent.event.EventBus;
+import software.amazon.disco.agent.event.Listener;
+import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
+import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;

--- a/aws-xray-auto-instrumentation-agent-runtime/pom.xml
+++ b/aws-xray-auto-instrumentation-agent-runtime/pom.xml
@@ -90,10 +90,11 @@
                 </executions>
                 <configuration>
                     <!-- Add our Bootstrap Agent for the integration tests -->
-                    <argLine>-javaagent:${com.amazonaws:aws-xray-auto-instrumentation-agent-bootstrap:jar}=servicename=IntegTest</argLine>
+                    <argLine>-javaagent:${com.amazonaws:aws-xray-auto-instrumentation-agent-bootstrap:jar}
+                             -Dcom.amazonaws.xray.strategy.tracingName=IntegTest
+                    </argLine>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2HandlerIT.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2HandlerIT.java
@@ -1,7 +1,6 @@
 package com.amazonaws.xray.agent.handlers.downstream;
 
 import com.amazonaws.xray.AWSXRay;
-import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.Cause;
 import com.amazonaws.xray.entities.Segment;
@@ -14,14 +13,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.mockito.Mockito;
-
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.async.EmptyPublisher;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/HttpClientHandlerIT.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/HttpClientHandlerIT.java
@@ -11,12 +11,10 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
 import java.net.URI;
 import java.util.Map;
@@ -25,9 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class HttpClientHandlerIT {
     private final static String TRACE_HEADER_KEY = TraceHeader.HEADER_KEY;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/MockHttpClient.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/downstream/MockHttpClient.java
@@ -1,0 +1,103 @@
+package com.amazonaws.xray.agent.handlers.downstream;
+
+import com.amazonaws.http.apache.client.impl.ConnectionManagerAwareHttpClient;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.impl.io.EmptyInputStream;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * TODO: When Disco removes its data accessor pattern in a future version, delete this & use a mock instead
+ */
+public class MockHttpClient implements ConnectionManagerAwareHttpClient {
+    private String responseContent;
+    private HttpUriRequest lastRequest; // Hacky way of spying on the last made request
+
+    public void setResponseContent(String responseContent) {
+        this.responseContent = responseContent;
+    }
+
+    public HttpUriRequest getLastRequest() {
+        return lastRequest;
+    }
+
+    @Override
+    public HttpClientConnectionManager getHttpClientConnectionManager() {
+        return null;
+    }
+
+    @Override
+    public HttpParams getParams() {
+        return null;
+    }
+
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        return null;
+    }
+
+    @Override
+    public HttpResponse execute(HttpUriRequest httpUriRequest) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public HttpResponse execute(HttpUriRequest httpUriRequest, HttpContext httpContext) throws IOException, ClientProtocolException {
+        this.lastRequest = httpUriRequest;
+        HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
+        BasicHttpEntity responseBody = new BasicHttpEntity();
+        InputStream in = EmptyInputStream.INSTANCE;
+        if(null != responseContent && !responseContent.isEmpty()) {
+            in = new ByteArrayInputStream(responseContent.getBytes(StandardCharsets.UTF_8));
+        }
+        responseBody.setContent(in);
+        httpResponse.setEntity(responseBody);
+        return httpResponse;
+    }
+
+    @Override
+    public HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<? extends T> responseHandler) throws IOException, ClientProtocolException {
+        return null;
+    }
+
+    @Override
+    public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<? extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
+        return (T) execute((HttpUriRequest) httpRequest, httpContext);
+    }
+}

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/MockHttpServletRequest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/MockHttpServletRequest.java
@@ -1,0 +1,382 @@
+package com.amazonaws.xray.agent.handlers.upstream;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.Part;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This is a "mocked" version of the HttpServletRequest interface that is actually implemented rather
+ * than simply mocked with Mockito because the reflection done by Mockito interferes with that done by
+ * Disco, causing incorrect stubbing.
+ *
+ * TODO: When Disco removes its data accessor pattern in a future version, delete this & use a mock instead
+ */
+public class MockHttpServletRequest implements HttpServletRequest {
+    private static Map<String, String> reqHeaderMap;
+    private String method;
+
+    static {
+        reqHeaderMap = new HashMap<>();
+        reqHeaderMap.put("host", "amazon.com");
+        reqHeaderMap.put("referer", "http://amazon.com/explore/something");
+        reqHeaderMap.put("user-agent", "Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0");
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return new Cookie[0];
+    }
+
+    @Override
+    public long getDateHeader(String s) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String s) {
+        return reqHeaderMap.get(s);
+    }
+
+    public void setHeader(String key, String val) {
+        reqHeaderMap.put(key, val);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String s) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return Collections.enumeration(reqHeaderMap.keySet());
+    }
+
+    @Override
+    public int getIntHeader(String s) {
+        return 0;
+    }
+
+    @Override
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    @Override
+    public String getPathInfo() {
+        return null;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public String getQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserInRole(String s) {
+        return false;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return new StringBuffer("http://request.amazon.com");
+    }
+
+    @Override
+    public String getServletPath() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean b) {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String s) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String s) throws UnsupportedEncodingException {
+
+    }
+
+    @Override
+    public int getContentLength() {
+        return 0;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getParameter(String s) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getParameterValues(String s) {
+        return new String[0];
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return null;
+    }
+
+    @Override
+    public String getProtocol() {
+        return "http";
+    }
+
+    @Override
+    public String getScheme() {
+        return null;
+    }
+
+    @Override
+    public String getServerName() {
+        return null;
+    }
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return "1.1.1.1";
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String s, Object o) {
+
+    }
+
+    @Override
+    public void removeAttribute(String s) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        return null;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String s) {
+        return null;
+    }
+
+    @Override
+    public String getRealPath(String s) {
+        return null;
+    }
+
+    @Override
+    public int getRemotePort() {
+        return 0;
+    }
+
+    @Override
+    public String getLocalName() {
+        return null;
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return "0.0.0.0";
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+}

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerIT.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerIT.java
@@ -13,10 +13,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +33,7 @@ public class ServletHandlerIT {
     private final static String SERVICE_NAME = "IntegTest";  // This is hardcoded in the Pom.xml file
     private HttpServlet theServlet;
 
-    private HttpServletRequest request;
+    private MockHttpServletRequest request;
     private HttpServletResponse response;
 
     private AWSXRayRecorder recorder;
@@ -46,15 +43,16 @@ public class ServletHandlerIT {
     public void setup() throws Exception {
         theServlet = new SimpleHttpServlet();
 
-        request = mock(HttpServletRequest.class);
+        request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setHeader(TRACE_HEADER_KEY, null);
         response = mock(HttpServletResponse.class);
+        when(response.getStatus()).thenReturn(200);
         mockEmitter = mock(UDPEmitter.class);
 
         recorder = AWSXRay.getGlobalRecorder();
         recorder.setSamplingStrategy(new AllSamplingStrategy());
         recorder.setEmitter(mockEmitter); // Even though we're sampling them all, none are sent. This is to test.
-
-        mockHttpObjects();
     }
 
     @After
@@ -74,7 +72,7 @@ public class ServletHandlerIT {
 
     @Test
     public void testReceivePostRequest() throws Exception {
-        when(request.getMethod()).thenReturn("POST");
+        request.setMethod("POST");
         theServlet.service(request, response);
 
         Segment currentSegment = interceptSegment();
@@ -139,8 +137,7 @@ public class ServletHandlerIT {
     @Test
     public void testReceiveTraceHeaderSampled() throws Exception {
         // Add trace header to X-Ray through the request object.
-        when(request.getHeader(TRACE_HEADER_KEY)).thenReturn(PREDEFINED_TRACE_HEADER_SAMPLED);
-        mockHttpObjects(); // We need to remock now that we added a new header
+        request.setHeader(TRACE_HEADER_KEY, PREDEFINED_TRACE_HEADER_SAMPLED);
         theServlet.service(request, response);
 
         Segment currentSegment = interceptSegment();
@@ -154,49 +151,19 @@ public class ServletHandlerIT {
     @Test
     public void testReceiveTraceHeaderUnsampled() throws Exception {
         // Add trace header to X-Ray through the request object.
-        when(request.getHeader(TRACE_HEADER_KEY)).thenReturn(PREDEFINED_TRACE_HEADER_NOT_SAMPLED);
-        mockHttpObjects();
+        request.setHeader(TRACE_HEADER_KEY, PREDEFINED_TRACE_HEADER_NOT_SAMPLED);
         theServlet.service(request, response);
 
         verify(mockEmitter, times(0)).sendSegment(any());
-    }
-
-    private void mockHttpObjects() {
-        // Mock HttpServletRequest object.
-        when(request.getMethod()).thenReturn("GET");
-        when(request.getProtocol()).thenReturn("http");
-
-        // Add common http header
-        Map<String, String> reqHeaderMap = new HashMap<>();
-        reqHeaderMap.put("host", "amazon.com");
-        reqHeaderMap.put("referer", "http://amazon.com/explore/something");
-        reqHeaderMap.put("user-agent", "Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0");
-        if (request.getHeader(TRACE_HEADER_KEY) != null) {
-            // Add trace header through mockito
-            reqHeaderMap.put(TRACE_HEADER_KEY, request.getHeader(TRACE_HEADER_KEY));
-        }
-        for (Map.Entry<String, String> entry : reqHeaderMap.entrySet()) {
-            when(request.getHeader(entry.getKey())).thenReturn(entry.getValue());
-        }
-        // Adding the header names is necessary for
-        when(request.getHeaderNames()).thenReturn(Collections.enumeration(reqHeaderMap.keySet()));
-
-        // Used for request event population.
-        when(request.getLocalAddr()).thenReturn("0.0.0.0");
-        when(request.getRemoteAddr()).thenReturn("1.1.1.1");
-        when(request.getRequestURL()).thenReturn(new StringBuffer("http://request.amazon.com"));
-
-        // Mock HttpServletResponse object
-        when(response.getStatus()).thenReturn(200);
     }
 
     private void verifyHttpSegment(Segment segment) {
         assertEquals(SERVICE_NAME, segment.getName());
 
         Map<String, String> httpRequestMap = (Map<String, String>) segment.getHttp().get("request");
-        assertEquals(httpRequestMap.get("method"), request.getMethod());
-        assertEquals(httpRequestMap.get("client_ip"), request.getLocalAddr());
-        assertEquals(httpRequestMap.get("url"), request.getRequestURL().toString());
+        assertEquals(request.getMethod(), httpRequestMap.get("method"));
+        assertEquals(request.getLocalAddr(), httpRequestMap.get("client_ip"));
+        assertEquals(request.getRequestURL().toString(), httpRequestMap.get("url"));
 
         Map<String, String> httpResponseMap = (Map<String, String>) segment.getHttp().get("response");
         assertEquals(response.getStatus(), httpResponseMap.get("status"));

--- a/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerIT.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/integtest/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerIT.java
@@ -15,7 +15,6 @@ import org.mockito.ArgumentCaptor;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/AgentRuntimeLoader.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/AgentRuntimeLoader.java
@@ -1,18 +1,17 @@
 package com.amazonaws.xray.agent;
 
-import com.amazonaws.xray.agent.handlers.XRayHandlerInterface;
-import software.amazon.disco.agent.event.EventBus;
 import com.amazonaws.xray.agent.config.XRaySDKConfiguration;
 import com.amazonaws.xray.agent.dispatcher.EventDispatcher;
+import com.amazonaws.xray.agent.handlers.XRayHandlerInterface;
 import com.amazonaws.xray.agent.handlers.downstream.AWSHandler;
 import com.amazonaws.xray.agent.handlers.downstream.AWSV2Handler;
 import com.amazonaws.xray.agent.handlers.downstream.HttpClientHandler;
 import com.amazonaws.xray.agent.handlers.upstream.ServletHandler;
 import com.amazonaws.xray.agent.listeners.XRayListener;
 import com.amazonaws.xray.agent.models.XRayTransactionState;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.disco.agent.event.EventBus;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/config/XRaySDKConfiguration.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/config/XRaySDKConfiguration.java
@@ -1,27 +1,27 @@
 package com.amazonaws.xray.agent.config;
 
 import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.agent.models.XRayTransactionContextResolver;
 import com.amazonaws.xray.agent.models.XRayTransactionState;
 import com.amazonaws.xray.config.DaemonConfiguration;
 import com.amazonaws.xray.contexts.LambdaSegmentContextResolver;
+import com.amazonaws.xray.contexts.SegmentContextResolverChain;
 import com.amazonaws.xray.emitters.UDPEmitter;
 import com.amazonaws.xray.entities.StringValidator;
 import com.amazonaws.xray.strategy.DefaultStreamingStrategy;
+import com.amazonaws.xray.strategy.DefaultThrowableSerializationStrategy;
 import com.amazonaws.xray.strategy.IgnoreErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.SegmentNamingStrategy;
 import com.amazonaws.xray.strategy.sampling.AllSamplingStrategy;
+import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
 import com.amazonaws.xray.strategy.sampling.NoSamplingStrategy;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import com.amazonaws.xray.AWSXRayRecorderBuilder;
-import com.amazonaws.xray.contexts.SegmentContextResolverChain;
-import com.amazonaws.xray.strategy.DefaultThrowableSerializationStrategy;
-import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/dispatcher/EventDispatcher.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/dispatcher/EventDispatcher.java
@@ -1,10 +1,9 @@
 package com.amazonaws.xray.agent.dispatcher;
 
-import software.amazon.disco.agent.event.Event;
 import com.amazonaws.xray.agent.handlers.XRayHandlerInterface;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.disco.agent.event.Event;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/XRayHandler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/XRayHandler.java
@@ -1,8 +1,7 @@
 package com.amazonaws.xray.agent.handlers;
 
-import software.amazon.disco.agent.concurrent.TransactionContext;
-import com.amazonaws.xray.agent.models.XRayTransactionState;
 import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.agent.models.XRayTransactionState;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
@@ -10,9 +9,9 @@ import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.strategy.sampling.SamplingRequest;
 import com.amazonaws.xray.strategy.sampling.SamplingResponse;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.disco.agent.concurrent.TransactionContext;
 
 import java.util.Map;
 import java.util.Optional;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSHandler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSHandler.java
@@ -1,12 +1,12 @@
 package com.amazonaws.xray.agent.handlers.downstream;
 
-import software.amazon.disco.agent.event.Event;
-import software.amazon.disco.agent.event.ServiceRequestEvent;
-import software.amazon.disco.agent.event.ServiceResponseEvent;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
 import com.amazonaws.xray.agent.handlers.XRayHandler;
 import com.amazonaws.xray.handlers.TracingHandler;
+import software.amazon.disco.agent.event.Event;
+import software.amazon.disco.agent.event.ServiceRequestEvent;
+import software.amazon.disco.agent.event.ServiceResponseEvent;
 
 import java.net.URL;
 

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2Handler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/AWSV2Handler.java
@@ -16,13 +16,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.disco.agent.event.AwsServiceDownstreamRequestEvent;
 import software.amazon.disco.agent.event.AwsServiceDownstreamResponseEvent;
 import software.amazon.disco.agent.event.Event;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import java.io.IOException;
 import java.net.URL;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/HttpClientHandler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/downstream/HttpClientHandler.java
@@ -1,17 +1,16 @@
 package com.amazonaws.xray.agent.handlers.downstream;
 
 import com.amazonaws.xray.AWSXRay;
-import software.amazon.disco.agent.event.Event;
-import software.amazon.disco.agent.event.HttpServiceDownstreamRequestEvent;
-import software.amazon.disco.agent.event.HttpServiceDownstreamResponseEvent;
 import com.amazonaws.xray.agent.handlers.XRayHandler;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.disco.agent.event.Event;
+import software.amazon.disco.agent.event.HttpServiceDownstreamRequestEvent;
+import software.amazon.disco.agent.event.HttpServiceDownstreamResponseEvent;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandler.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandler.java
@@ -1,13 +1,13 @@
 package com.amazonaws.xray.agent.handlers.upstream;
 
-import software.amazon.disco.agent.event.Event;
-import software.amazon.disco.agent.event.HttpNetworkProtocolRequestEvent;
-import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
-import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 import com.amazonaws.xray.agent.handlers.XRayHandler;
 import com.amazonaws.xray.agent.models.XRayTransactionState;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.TraceHeader;
+import software.amazon.disco.agent.event.Event;
+import software.amazon.disco.agent.event.HttpNetworkProtocolRequestEvent;
+import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
+import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/listeners/XRayListener.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/listeners/XRayListener.java
@@ -1,5 +1,8 @@
 package com.amazonaws.xray.agent.listeners;
 
+import com.amazonaws.xray.agent.dispatcher.EventDispatcher;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import software.amazon.disco.agent.event.Event;
 import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
 import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
@@ -7,10 +10,6 @@ import software.amazon.disco.agent.event.Listener;
 import software.amazon.disco.agent.event.ServiceEvent;
 import software.amazon.disco.agent.event.ServiceRequestEvent;
 import software.amazon.disco.agent.event.ServiceResponseEvent;
-import com.amazonaws.xray.agent.dispatcher.EventDispatcher;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 public class XRayListener implements Listener {
     private static final Log log = LogFactory.getLog(XRayListener.class);

--- a/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/models/XRayTransactionContext.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/main/java/com/amazonaws/xray/agent/models/XRayTransactionContext.java
@@ -1,6 +1,5 @@
 package com.amazonaws.xray.agent.models;
 
-import software.amazon.disco.agent.concurrent.TransactionContext;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.contexts.SegmentContext;
 import com.amazonaws.xray.entities.Entity;
@@ -9,9 +8,9 @@ import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.exceptions.SegmentNotFoundException;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import software.amazon.disco.agent.concurrent.TransactionContext;
 
 /**
  * X-Ray-friendly context that utilizes the TransactionContext object to propagate across thread boundaries. This context

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/AgentRuntimeLoaderTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/AgentRuntimeLoaderTest.java
@@ -1,25 +1,25 @@
 package com.amazonaws.xray.agent;
 
-import com.amazonaws.xray.agent.handlers.downstream.AWSHandler;
-import com.amazonaws.xray.agent.handlers.downstream.AWSV2Handler;
-import com.amazonaws.xray.agent.listeners.XRayListener;
-import org.apache.commons.io.FilenameUtils;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import software.amazon.disco.agent.event.EventBus;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.agent.config.XRaySDKConfiguration;
+import com.amazonaws.xray.agent.handlers.downstream.AWSHandler;
+import com.amazonaws.xray.agent.handlers.downstream.AWSV2Handler;
+import com.amazonaws.xray.agent.listeners.XRayListener;
 import com.amazonaws.xray.agent.models.XRayTransactionState;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import software.amazon.disco.agent.event.EventBus;
 
 import java.io.File;
 import java.net.URL;
@@ -29,8 +29,8 @@ import java.net.URL;
 @PowerMockIgnore("javax.net.ssl.*")
 public class AgentRuntimeLoaderTest {
     private final String serviceName = "TestService";
-    private static final String CONFIG_FILE_SYS_PROPERTY="com.amazonaws.xray.configFile";
-    private static final String CONFIG_FILE_DEFAULT_NAME="xray-agent.json";
+    private static final String CONFIG_FILE_SYS_PROPERTY = "com.amazonaws.xray.configFile";
+    private static final String CONFIG_FILE_DEFAULT_NAME = "xray-agent.json";
 
     @Mock
     private XRayListener listenerMock;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/config/XRaySDKConfigurationTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/config/XRaySDKConfigurationTest.java
@@ -22,15 +22,15 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.mockito.ArgumentCaptor;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class XRaySDKConfigurationTest {
     private static final String JVM_NAME = "jvm_name";
@@ -238,7 +238,7 @@ public class XRaySDKConfigurationTest {
     @Test
     public void testInvalidSamplingRuleManifest() {
         AWSXRayRecorderBuilder builderMock = mock(AWSXRayRecorderBuilder.class);
-        configMap.put("sampingRulesManifest", "notAFile");
+        configMap.put("samplingRulesManifest", "notAFile");
         config.setAgentConfiguration(new AgentConfiguration(configMap));
 
         config.init(builderMock);
@@ -251,7 +251,7 @@ public class XRaySDKConfigurationTest {
     @Test
     public void testValidSamplingRuleManifest() {
         AWSXRayRecorderBuilder builderMock = mock(AWSXRayRecorderBuilder.class);
-        configMap.put("sampingRulesManifest", "/path/to/file");
+        configMap.put("samplingRulesManifest", "/path/to/file");
         config.setAgentConfiguration(new AgentConfiguration(configMap));
 
         config.init(builderMock);

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/dispatcher/EventDispatcherTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/dispatcher/EventDispatcherTest.java
@@ -1,14 +1,14 @@
 package com.amazonaws.xray.agent.dispatcher;
 
-import software.amazon.disco.agent.event.ServiceActivityRequestEvent;
-import software.amazon.disco.agent.event.ServiceActivityResponseEvent;
-import software.amazon.disco.agent.event.ServiceRequestEvent;
 import com.amazonaws.xray.agent.handlers.XRayHandlerInterface;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
+import software.amazon.disco.agent.event.ServiceActivityRequestEvent;
+import software.amazon.disco.agent.event.ServiceActivityResponseEvent;
+import software.amazon.disco.agent.event.ServiceRequestEvent;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/handlers/downstream/AWSHandlerTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/handlers/downstream/AWSHandlerTest.java
@@ -1,7 +1,5 @@
 package com.amazonaws.xray.agent.handlers.downstream;
 
-import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
-import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
 import com.amazonaws.ResponseMetadata;
@@ -23,6 +21,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
+import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
+import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/handlers/upstream/ServletHandlerTest.java
@@ -1,7 +1,5 @@
 package com.amazonaws.xray.agent.handlers.upstream;
 
-import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
-import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.agent.models.XRayTransactionState;
 import com.amazonaws.xray.entities.Segment;
@@ -15,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
+import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
+import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/listeners/XRayListenerTest.java
+++ b/aws-xray-auto-instrumentation-agent-runtime/src/test/java/com/amazonaws/xray/agent/listeners/XRayListenerTest.java
@@ -1,5 +1,12 @@
 package com.amazonaws.xray.agent.listeners;
 
+import com.amazonaws.xray.agent.dispatcher.EventDispatcher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
 import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 import software.amazon.disco.agent.event.ServiceActivityRequestEvent;
@@ -8,16 +15,8 @@ import software.amazon.disco.agent.event.ServiceDownstreamRequestEvent;
 import software.amazon.disco.agent.event.ServiceDownstreamResponseEvent;
 import software.amazon.disco.agent.event.TransactionBeginEvent;
 import software.amazon.disco.agent.event.TransactionEvent;
-import com.amazonaws.xray.agent.dispatcher.EventDispatcher;
-import com.amazonaws.xray.agent.listeners.XRayListener;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
*Description of changes:*
This pull request changes some of our integration tests to be compatible with future versions of disco where its reflective data access makes mocking some classes impossible. We do this by instantiating our own extensions of these classes, which are themselves effectively hard-coded mocks. We should be able to return to the original mocking strategy on a further still version of disco, but for now this strategy is compatible with all versions.

Pretty much all other changes in this PR are non-substantive style changes/typo corrections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
