### PR TITLE
added build step to rewrite the disco agent manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // Expose DiSCo version to subprojects
-val discoVersion by extra("0.10.1")
+val discoVersion by extra("0.10.0")
 
 subprojects {
     version = "2.7.1"


### PR DESCRIPTION
*Description of changes:*
Since Disco points to its JAR name in its agent's manifest file and we rename the disco agent JAR file, we also have to rewrite the manifest. This logic automates that for us.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
