### PR TITLE
Fixed upstream sampling bug

### DIFF
--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
@@ -43,16 +43,11 @@ public class ServletHandler extends XRayHandler {
         }
         transactionState.withTraceheaderString(headerData);
 
-        Optional<TraceHeader> traceHeader = Optional.empty();
-        String traceHeaderString = transactionState.getTraceHeader();
-        // If the trace header string is null, then this is the origin call.
-        if (traceHeaderString != null) {
-            traceHeader = Optional.of(TraceHeader.fromString(traceHeaderString));
-        }
+        TraceHeader traceHeader = TraceHeader.fromString(transactionState.getTraceHeader());
         Segment segment = beginSegment(XRayTransactionState.getServiceName(), traceHeader);
 
         // Obtain sampling decision
-        boolean shouldSample = getSamplingDecision(transactionState, traceHeader);
+        boolean shouldSample = getSamplingDecision(transactionState);
         segment.setSampled(shouldSample);
 
         // Add HTTP Information

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/models/XRayTransactionState.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/models/XRayTransactionState.java
@@ -1,5 +1,7 @@
 package com.amazonaws.xray.agent.runtime.models;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Contains state information for each logical request/response transaction event.
  *
@@ -47,14 +49,12 @@ public class XRayTransactionState {
         return this;
     }
 
-    public XRayTransactionState withTraceheaderString(String traceHeaderString) {
-        // can be null
+    public XRayTransactionState withTraceheaderString(@Nullable String traceHeaderString) {
         this.traceHeader = traceHeaderString;
         return this;
     }
 
-    public XRayTransactionState withOrigin(String origin) {
-        // can be null
+    public XRayTransactionState withOrigin(@Nullable String origin) {
         this.origin = origin;
         return this;
     }
@@ -83,13 +83,13 @@ public class XRayTransactionState {
         return this.serviceType;
     }
 
+    @Nullable
     public String getTraceHeader() {
-        // can be null
         return this.traceHeader;
     }
 
+    @Nullable
     public String getOrigin() {
-        // can be null
         return this.origin;
     }
 

--- a/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/XRayHandlerTest.java
+++ b/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/XRayHandlerTest.java
@@ -1,0 +1,74 @@
+package com.amazonaws.xray.agent.runtime.handlers;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.agent.runtime.models.XRayTransactionState;
+import com.amazonaws.xray.entities.TraceHeader;
+import com.amazonaws.xray.strategy.sampling.SamplingResponse;
+import com.amazonaws.xray.strategy.sampling.SamplingStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.disco.agent.event.Event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class XRayHandlerTest {
+    private FakeHandler fakeHandler;
+
+    @Mock
+    private SamplingStrategy mockSamplingStrategy;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(mockSamplingStrategy.shouldTrace(any())).thenReturn(new SamplingResponse());
+        fakeHandler = new FakeHandler();
+
+        AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.standard()
+            .withSamplingStrategy(mockSamplingStrategy)
+            .build()
+        );
+
+        AWSXRay.clearTraceEntity();
+    }
+
+    @Test
+    public void testRespectUpstreamSamplingDecision() {
+        XRayTransactionState state = new XRayTransactionState();
+        TraceHeader header = new TraceHeader(null, null, TraceHeader.SampleDecision.SAMPLED);
+        state.withTraceheaderString(header.toString());
+        boolean decision = fakeHandler.getSamplingDecision(state);
+
+        assertThat(decision).isTrue();
+        verify(mockSamplingStrategy, never()).shouldTrace(any());
+    }
+
+    @Test
+    public void testComputeSamplingDecisionForUnknown() {
+        XRayTransactionState state = new XRayTransactionState();
+        fakeHandler.getSamplingDecision(state);
+
+        assertThat(state.getTraceHeader()).isNull();
+        verify(mockSamplingStrategy, times((1))).shouldTrace(any());
+    }
+
+    private static class FakeHandler extends XRayHandler {
+
+        @Override
+        public void handleRequest(Event event) {
+        }
+
+        @Override
+        public void handleResponse(Event event) {
+        }
+    }
+}
+
+

--- a/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerTest.java
+++ b/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerTest.java
@@ -13,11 +13,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.disco.agent.event.HttpServletNetworkRequestEvent;
 import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 
@@ -26,8 +23,6 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.net.ssl.*")
 public class ServletHandlerTest {
     public static final String HEADER_KEY = "X-Amzn-Trace-Id";
 


### PR DESCRIPTION
*Issue #, if available:*
#64 

*Description of changes:*
Fixes a bug where the `ServletHandler` would assume upstream `UNKNOWN` sampling decisions to be false, and instead we compute a new sampling decision in this case. Added unit tests to verify behavior.

Also sprinkled in some `Nullable` usage, removed some unnecessary `Optional` usage, and some other small cleanups. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
