### PR TITLE
Fixed trace ID injection with spring boot

### DIFF
--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfiguration.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfiguration.java
@@ -360,7 +360,7 @@ public class XRaySDKConfiguration {
         }
         traceIdInjectionConfigured = true;
 
-        // We must use the context class loader because the whole reason we're lazy loading is the injection libraries
+        // We must use the context class loader because the whole reason we're lazy loading the injection libraries
         // is that they're only visible to the classloader used by the customer app
         recorder.addAllSegmentListeners(getTraceIdInjectorsReflectively(Thread.currentThread().getContextClassLoader()));
     }

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfiguration.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfiguration.java
@@ -1,6 +1,7 @@
 package com.amazonaws.xray.agent.runtime.config;
 
 import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.agent.runtime.models.XRayTransactionContextResolver;
 import com.amazonaws.xray.agent.runtime.models.XRayTransactionState;
@@ -30,7 +31,9 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -55,6 +58,11 @@ public class XRaySDKConfiguration {
     static final String ENABLED_ENVIRONMENT_VARIABLE_KEY = "AWS_XRAY_TRACING_ENABLED";
     static final String ENABLED_SYSTEM_PROPERTY_KEY = "com.amazonaws.xray.tracingEnabled";
 
+    private static final String[] TRACE_ID_INJECTION_CLASSES = {
+            "com.amazonaws.xray.log4j.Log4JSegmentListener",
+            "com.amazonaws.xray.slf4j.SLF4JSegmentListener"
+    };
+
     private static final Log log = LogFactory.getLog(XRaySDKConfiguration.class);
 
     /* JSON factory used instead of mapper for performance */
@@ -65,6 +73,9 @@ public class XRaySDKConfiguration {
 
     /* Configuration storage */
     private AgentConfiguration agentConfiguration;
+
+    /* Indicator for whether trace ID injection has been configured */
+    private boolean traceIdInjectionConfigured;
 
     /* AWS Manifest whitelist, for runtime loader access */
     @Nullable
@@ -274,9 +285,16 @@ public class XRaySDKConfiguration {
 
         // Trace ID Injection
         if (agentConfiguration.isTraceIdInjection()) {
-            final String prefix = agentConfiguration.getTraceIdInjectionPrefix();
-            tryAddTraceIdInjection(builder, "com.amazonaws.xray.log4j.Log4JSegmentListener", prefix);
-            tryAddTraceIdInjection(builder, "com.amazonaws.xray.slf4j.SLF4JSegmentListener", prefix);
+            // TODO: Include the trace ID injection libraries in the agent JAR and use this reflective approach to
+            // only enable them if their corresponding logging libs are in the context classloader
+            List<SegmentListener> listeners = getTraceIdInjectorsReflectively(ClassLoader.getSystemClassLoader());
+
+            if (!listeners.isEmpty()) {
+                traceIdInjectionConfigured = true;
+                for (SegmentListener listener : listeners) {
+                    builder.withSegmentListener(listener);
+                }
+            }
         }
 
         // Max stack trace length
@@ -329,6 +347,24 @@ public class XRaySDKConfiguration {
         AWSXRay.setGlobalRecorder(builder.build());
     }
 
+    /**
+     * Attempts to enable trace ID injection via reflection. This can be called during runtime as opposed to agent
+     * startup in case required trace ID injection classes aren't available on the classpath during premain.
+     *
+     * @param recorder - the X-Ray Recorder to configure
+     */
+    public void lazyLoadTraceIdInjection(AWSXRayRecorder recorder) {
+        // Fail fast if injection disabled or we've already tried to lazy load
+        if (!agentConfiguration.isTraceIdInjection() || traceIdInjectionConfigured) {
+            return;
+        }
+        traceIdInjectionConfigured = true;
+
+        // We must use the context class loader because the whole reason we're lazy loading is the injection libraries
+        // is that they're only visible to the classloader used by the customer app
+        recorder.addAllSegmentListeners(getTraceIdInjectorsReflectively(Thread.currentThread().getContextClassLoader()));
+    }
+
     private AgentConfiguration parseConfig(URL configFile) throws IOException {
         Map<String, String> propertyMap = new HashMap<>();
         JsonParser parser = factory.createParser(configFile);
@@ -350,15 +386,21 @@ public class XRaySDKConfiguration {
         return new AgentConfiguration(propertyMap);
     }
 
-    private void tryAddTraceIdInjection(AWSXRayRecorderBuilder builder, String className, String prefix) {
-        try {
-            Class<?> listenerClass = Class.forName(className, true, ClassLoader.getSystemClassLoader());
-            SegmentListener listener = (SegmentListener) listenerClass.getConstructor(String.class).newInstance(prefix);
-            builder.withSegmentListener(listener);
-            log.debug("Enabled AWS X-Ray trace ID injection into logs using " + className);
-        } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
-            log.debug("Didn't enable AWS X-Ray trace ID injection into logs because " + className
-                    + " could not be found on system class path");
+    private List<SegmentListener> getTraceIdInjectorsReflectively(ClassLoader classLoader) {
+        final List<SegmentListener> listeners = new ArrayList<>();
+        final String prefix = agentConfiguration.getTraceIdInjectionPrefix();
+        log.debug("Prefix is: " + prefix);
+        for (String className : TRACE_ID_INJECTION_CLASSES) {
+            try {
+                Class<?> listenerClass = Class.forName(className, true, classLoader);
+                SegmentListener listener = (SegmentListener) listenerClass.getConstructor(String.class).newInstance(prefix);
+                listeners.add(listener);
+                log.debug("Enabled AWS X-Ray trace ID injection into logs using " + className);
+            } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
+                log.debug("Could not find trace ID injection class " + className + " with class loader " + classLoader.getClass().getSimpleName());
+            }
         }
+
+        return listeners;
     }
 }

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/XRayHandler.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/XRayHandler.java
@@ -1,6 +1,7 @@
 package com.amazonaws.xray.agent.runtime.handlers;
 
 import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.agent.runtime.models.XRayTransactionState;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
@@ -94,6 +95,10 @@ public abstract class XRayHandler implements XRayHandlerInterface {
         }
 
         return segment;
+    }
+
+    protected AWSXRayRecorder getGlobalRecorder() {
+        return AWSXRay.getGlobalRecorder();
     }
 
     protected Segment beginSegment(String segmentName, TraceHeader traceHeader) {

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
@@ -31,7 +31,7 @@ public class ServletHandler extends XRayHandler {
     public void handleRequest(Event event) {
         HttpServletNetworkRequestEvent requestEvent = (HttpServletNetworkRequestEvent) event;
 
-        // For Spring Boot apps, the trace ID injection libraries will not be visible on classpath til after startup,
+        // For Spring Boot apps, the trace ID injection libraries will not be visible on classpath until after startup,
         // so we must try to lazy load them as early as possible
         XRaySDKConfiguration.getInstance().lazyLoadTraceIdInjection(getGlobalRecorder());
 

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
@@ -1,5 +1,6 @@
 package com.amazonaws.xray.agent.runtime.handlers.upstream;
 
+import com.amazonaws.xray.agent.runtime.config.XRaySDKConfiguration;
 import com.amazonaws.xray.agent.runtime.handlers.XRayHandler;
 import com.amazonaws.xray.agent.runtime.models.XRayTransactionState;
 import com.amazonaws.xray.entities.Segment;
@@ -11,7 +12,6 @@ import software.amazon.disco.agent.event.HttpServletNetworkResponseEvent;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * This handler handles an HttpEvent usually retrieved as a result of servlet interception and generates a segment.
@@ -30,6 +30,10 @@ public class ServletHandler extends XRayHandler {
     @Override
     public void handleRequest(Event event) {
         HttpServletNetworkRequestEvent requestEvent = (HttpServletNetworkRequestEvent) event;
+
+        // For Spring Boot apps, the trace ID injection libraries will not be visible on classpath til after startup,
+        // so we must try to lazy load them as early as possible
+        XRaySDKConfiguration.getInstance().lazyLoadTraceIdInjection(getGlobalRecorder());
 
         // HttpEvents are seen as servlet invocations, so in every request, we mark that we are serving an Http request
         // In X-Ray's context, this means that if we receive a activity event, to start generating a segment.

--- a/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfigurationTest.java
+++ b/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/config/XRaySDKConfigurationTest.java
@@ -454,4 +454,13 @@ public class XRaySDKConfigurationTest {
 
         Assert.assertTrue(AWSXRay.getGlobalRecorder().getSegmentContextResolverChain().resolve() instanceof ThreadLocalSegmentContext);
     }
+
+    @Test
+    public void testLazyLoadTraceIdInjection() {
+        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.defaultRecorder();
+        config.setAgentConfiguration(new AgentConfiguration());
+        config.lazyLoadTraceIdInjection(recorder);
+
+        Assert.assertEquals(2, recorder.getSegmentListeners().size());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
Refactored the trace ID injection logic to try to enable it once during premain, and again while handling the first instrumented request. This allows us to check for the trace ID injection classes (Log4JSegmentListener and SLF4JSegmentListener) using the customer app's class loader, in case they're using a custom one, as is the case for Spring Boot apps.

In the future, as I noted in my TODO task, we should bundle those two classes in the Agent JAR and enable trace ID injection by default so long as the corresponding logging library (Log4J or SLF4J) is available on the customer's class loader. But this was a little too much work for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
