### PR TITLE
added check for x-forwarded-for header

### DIFF
--- a/aws-xray-agent-plugin/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerIntegTest.java
+++ b/aws-xray-agent-plugin/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerIntegTest.java
@@ -162,7 +162,7 @@ public class ServletHandlerIntegTest {
 
         Map<String, String> httpRequestMap = (Map<String, String>) segment.getHttp().get("request");
         assertEquals(request.getMethod(), httpRequestMap.get("method"));
-        assertEquals(request.getLocalAddr(), httpRequestMap.get("client_ip"));
+        assertEquals(request.getRemoteAddr(), httpRequestMap.get("client_ip"));
         assertEquals(request.getRequestURL().toString(), httpRequestMap.get("url"));
 
         Map<String, String> httpResponseMap = (Map<String, String>) segment.getHttp().get("response");

--- a/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
+++ b/aws-xray-agent/src/main/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandler.java
@@ -24,6 +24,7 @@ public class ServletHandler extends XRayHandler {
     private static final String USER_AGENT_KEY = "user_agent";
     private static final String FORWARDED_FOR_KEY_LOWER = "x-forwarded-for";
     private static final String FORWARDED_FOR_KEY_UPPER = "X-Forwarded-For";
+    private static final String FORWARDED_FOR_ATTRIB = "x_forwarded_for";
 
     private static final String RESPONSE_KEY = "response";
     private static final String HTTP_REQUEST_KEY = "request";
@@ -40,7 +41,8 @@ public class ServletHandler extends XRayHandler {
         // HttpEvents are seen as servlet invocations, so in every request, we mark that we are serving an Http request
         // In X-Ray's context, this means that if we receive a activity event, to start generating a segment.
         XRayTransactionState transactionState = getTransactionState();
-        populateHeaderToTransactionState(requestEvent, transactionState);
+        addRequestDataToTransactionState(requestEvent, transactionState);
+        boolean ipForwarded = addClientIPToTransactionState(requestEvent, transactionState);
 
         // TODO Fix request event bug so that getHeaderData is lower cased. This needs to be case insensitive
         // See: https://github.com/awslabs/disco/issues/14
@@ -63,6 +65,7 @@ public class ServletHandler extends XRayHandler {
         requestAttributes.put(USER_AGENT_KEY, transactionState.getUserAgent());
         requestAttributes.put(METHOD_KEY, transactionState.getMethod());
         requestAttributes.put(CLIENT_IP_KEY, transactionState.getClientIP());
+        if (ipForwarded) requestAttributes.put(FORWARDED_FOR_ATTRIB, true);
         segment.putHttp(HTTP_REQUEST_KEY, requestAttributes);
     }
 
@@ -110,20 +113,27 @@ public class ServletHandler extends XRayHandler {
      * @param requestEvent     The HttpNetworkProtocolRequestEvent that was captured from the event bus.
      * @param transactionState The current XRay transactional state
      */
-    private void populateHeaderToTransactionState(HttpNetworkProtocolRequestEvent requestEvent, XRayTransactionState transactionState) {
-        String clientIP = requestEvent.getLocalIPAddress();
-        if (clientIP == null || clientIP.isEmpty()) {
-            clientIP = requestEvent.getHeaderData(FORWARDED_FOR_KEY_LOWER);
-        }
-        if (clientIP == null || clientIP.isEmpty()) {
-            clientIP = requestEvent.getHeaderData(FORWARDED_FOR_KEY_UPPER);
-        }
-
+    private void addRequestDataToTransactionState(HttpNetworkProtocolRequestEvent requestEvent, XRayTransactionState transactionState) {
         transactionState.withHost(requestEvent.getHost())
                 .withMethod(requestEvent.getMethod())
                 .withUrl(requestEvent.getURL())
                 .withUserAgent(requestEvent.getUserAgent())
-                .withClientIP(clientIP)
                 .withTraceheaderString(requestEvent.getHeaderData(HEADER_KEY));
+    }
+
+    private boolean addClientIPToTransactionState(HttpNetworkProtocolRequestEvent requestEvent, XRayTransactionState transactionState) {
+        String clientIP = requestEvent.getHeaderData(FORWARDED_FOR_KEY_UPPER);
+        boolean forwarded = true;
+
+        if (clientIP == null || clientIP.isEmpty()) {
+            clientIP = requestEvent.getHeaderData(FORWARDED_FOR_KEY_LOWER);
+        }
+        if (clientIP == null || clientIP.isEmpty()) {
+            clientIP = requestEvent.getRemoteIPAddress();
+            forwarded = false;
+        }
+
+        transactionState.withClientIP(clientIP);
+        return forwarded;
     }
 }

--- a/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerTest.java
+++ b/aws-xray-agent/src/test/java/com/amazonaws/xray/agent/runtime/handlers/upstream/ServletHandlerTest.java
@@ -81,7 +81,8 @@ public class ServletHandlerTest {
 
         Map<String, String> httpMap = (Map<String, String>) servletSegment.getHttp().get("request");
         Assert.assertEquals(METHOD, httpMap.get("method"));
-        Assert.assertEquals(DST_IP, httpMap.get("client_ip"));
+        Assert.assertEquals(SRC_IP, httpMap.get("client_ip"));
+        Assert.assertNull(httpMap.get("x_forwarded_for"));
         Assert.assertEquals(URL, httpMap.get("url"));
         Assert.assertEquals(USER_AGENT, httpMap.get("user_agent"));
 
@@ -135,8 +136,9 @@ public class ServletHandlerTest {
 
         Assert.assertNull(requestEvent.getLocalIPAddress());
         Assert.assertNotNull(segment);
-        Map<String, String> requestMap = (Map<String, String>) segment.getHttp().get("request");
-        Assert.assertNotNull(forwardedForIP, requestMap.get("client_ip"));
+        Map<String, Object> requestMap = (Map<String, Object>) segment.getHttp().get("request");
+        Assert.assertEquals(forwardedForIP, requestMap.get("client_ip"));
+        Assert.assertEquals(true, requestMap.get("x_forwarded_for"));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#78

*Description of changes:*
Adds a fallback check for the `X-Forwarded-For` header to record Client IP. Header data from disco is case-sensitive, so I checked for the lower-case and capitalized versions. I've also opened https://github.com/awslabs/disco/issues/14 in the underlying Disco framework the agent uses, for the more general fix of case-insensitive headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
