### PR TITLE
Code coverage report generation

### DIFF
--- a/.github/workflows/continuous_build.yml
+++ b/.github/workflows/continuous_build.yml
@@ -1,5 +1,11 @@
 name: Continuous Build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -13,23 +19,42 @@ jobs:
         java:
           - 8
           - 11
+        include:
+          - os: ubuntu-latest
+            java: 11
+            coverage: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
+
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Cache Gradle Modules
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ hashFiles('**/*.gradle.kts') }}
+
       - name: Cache Gradle Wrapper
         uses: actions/cache@v1
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Execute Gradle build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build ${{ matrix.coverage && 'jacocoTestReport' || '' }} --stacktrace
         shell: bash
+
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}
+        with:
+          files: ./aws-xray-agent/build/reports/jacoco/test/jacocoTestReport.xml
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.coverage }}
+        with:
+          name: coverage-report
+          path: ./aws-xray-agent/build/reports/jacoco/test/html

--- a/aws-xray-agent/build.gradle.kts
+++ b/aws-xray-agent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java`
+    `jacoco`
 }
 
 description = "AWS X-Ray Runtime Java Agent"
@@ -29,4 +30,21 @@ dependencies {
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-slf4j")
     testImplementation("org.apache.logging.log4j:log4j-api:2.13.3")
     testImplementation("ch.qos.logback:logback-classic:1.3.0-alpha5")
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+}
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // tests are required to run before generating the report
+}
+
+jacoco {
+    toolVersion = "0.8.6"
+}
+tasks.jacocoTestReport {
+    reports {
+        xml.isEnabled = true
+        html.isEnabled = true
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Similar to [what is done](https://github.com/aws/aws-xray-sdk-java/pull/261) for the java sdk using the jacoco plugin.
@willarmiros explained to me that since the agent is built as a plugin for [Disco](https://github.com/awslabs/disco), all the core logic is contained within the `aws-xray-agent` module and rest of the modules contain benchmark and integration tests. We only need to be concerned with the coverage report for the `aws-xray-agent` module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
