### PR TITLE
Remove third party action

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -31,16 +31,10 @@ jobs:
           else
             aws cloudwatch put-metric-data --metric-name XRayJavaAgentGithubDistributionUnavailability --dimensions failure=rate --namespace MonitorAgent --value 0 --timestamp $(date +%s)
           fi
-      
-      - name: Get Latest tag
-        id: latest_tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-      
+       
       - name: Pull Java agent from Maven
         id: distribution-availability-maven
-        run: |
-          latest_tag=$(echo ${{ steps.latest_tag.outputs.tag }} | sed -e 's/v//')
-          wget https://repo.maven.apache.org/maven2/com/amazonaws/aws-xray-agent-plugin/$latest_tag/aws-xray-agent-plugin-$latest_tag.jar
+        run: wget https://repo.maven.apache.org/maven2/com/amazonaws/aws-xray-agent-plugin/2.8.0/aws-xray-agent-plugin-2.8.0.jar
         
       - name: Publish metric on X-Ray Java agent distribution availability (Maven)
         if: ${{ always() }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR removes third party action to get the latest tag in favor of this [issue](https://github.com/aws/aws-xray-java-agent/issues/96). Ideally it would be good to set up smoke test for this workflow in future and that should be able to resolve to the latest version of the distribution so we can avoid using third party action even right now. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
