### PR TITLE
Add auto-publishing workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -26,6 +26,8 @@ jobs:
             GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
             GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
             GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+            GRGIT_USER: ${{ github.actor }}
+            GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -17,18 +17,18 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
 
       - name: Build release with Gradle
-          uses: burrunan/gradle-cache-action@v1
-          with:
-            arguments: build final closeSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
-          env:
-            CI: true
-            SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-            SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-            GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-            GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-            GRGIT_USER: ${{ github.actor }}
-            GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+        uses: burrunan/gradle-cache-action@v1
+        with:
+          arguments: build final closeSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+        env:
+          CI: true
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GRGIT_USER: ${{ github.actor }}
+          GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,3 +1,4 @@
+name: Release X-Ray Java Agent
 on:
   workflow_dispatch:
     inputs:
@@ -6,7 +7,7 @@ on:
         required: true
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 11
       - uses: gradle/wrapper-validation-action@v1
 
-      - name: Build release with Gradle
+      - name: Publish release with Gradle
         uses: burrunan/gradle-cache-action@v1
         with:
           arguments: build final closeSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Build release with Gradle
+          uses: burrunan/gradle-cache-action@v1
+          with:
+            arguments: build final closeSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          env:
+            CI: true
+            SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+            SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+            GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+            GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          release_name: Release ${{ github.event.inputs.version }}
+          body: Releasing version ${{ github.event.inputs.version }} of the AWS X-Ray Auto-Instrumentation agent for Java. Download it below. Please see [CHANGELOG](https://github.com/aws/aws-xray-java-agent/blob/master/CHANGELOG.md) for details.
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: aws-xray-agent-plugin/build/dist/xray-agent.zip
+          asset_name: xray-agent.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Publish release with Gradle
         uses: burrunan/gradle-cache-action@v1
         with:
-          arguments: build final closeSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
         env:
           CI: true
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -39,7 +39,7 @@ jobs:
           tag_name: v${{ github.event.inputs.version }}
           release_name: Release ${{ github.event.inputs.version }}
           body: Releasing version ${{ github.event.inputs.version }} of the AWS X-Ray Auto-Instrumentation agent for Java. Download it below. Please see [CHANGELOG](https://github.com/aws/aws-xray-java-agent/blob/master/CHANGELOG.md) for details.
-          draft: true
+          draft: false
           prerelease: false
 
       - name: Upload Release Asset

--- a/aws-xray-agent-benchmark/build.gradle.kts
+++ b/aws-xray-agent-benchmark/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     jmh("org.openjdk.jmh:jmh-generator-annprocess:${JMH_VERSION}")
     jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:${JMH_VERSION}")
 
-    jmh(platform("com.amazonaws:aws-xray-recorder-sdk-bom:${version}"))
+    jmh(platform("com.amazonaws:aws-xray-recorder-sdk-bom:${rootProject.extra["xraySdkVersion"]}"))
 }
 
 // JMH plugin docs: https://github.com/melix/jmh-gradle-plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,10 +27,6 @@ nexusPublishing {
     }
 }
 
-nebulaRelease {
-    addReleaseBranchPattern("auto-publishing")
-}
-
 allprojects {
 //    version = "2.8.0"
     group = "com.amazonaws"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,10 @@ nexusPublishing {
     }
 }
 
+nebulaRelease {
+    addReleaseBranchPattern("main")
+}
+
 allprojects {
 //    version = "2.8.0"
     group = "com.amazonaws"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ nexusPublishing {
     repositories {
         sonatype {
             nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ val releaseTask = tasks.named("release")
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"))
+            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ nebulaRelease {
     addReleaseBranchPattern("auto-publishing")
 }
 
-subprojects {
+allprojects {
 //    version = "2.8.0"
     group = "com.amazonaws"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-//import nebula.plugin.release.git.opinion.Strategies
 
 plugins {
     id("com.github.johnrengelman.shadow") apply false
@@ -7,14 +6,11 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin")
 }
 
-// Expose DiSCo version to subprojects
+// Expose DiSCo & X-Ray SDK version to subprojects
 val discoVersion by extra("0.10.0")
+val xraySdkVersion by extra("2.8.0")
 
 val releaseTask = tasks.named("release")
-
-//release {
-//    defaultVersionStrategy = Strategies.getSNAPSHOT()
-//}
 
 nexusPublishing {
     repositories {
@@ -32,7 +28,6 @@ nebulaRelease {
 }
 
 allprojects {
-//    version = "2.8.0"
     group = "com.amazonaws"
 
     repositories {
@@ -68,7 +63,7 @@ allprojects {
 
         dependencies {
             // BOMs for common projects
-            add("implementation", platform("com.amazonaws:aws-xray-recorder-sdk-bom:2.8.0"))
+            add("implementation", platform("com.amazonaws:aws-xray-recorder-sdk-bom:${xraySdkVersion}"))
             add("implementation", platform("software.amazon.disco:disco-toolkit-bom:${discoVersion}"))
             add("implementation", platform("com.fasterxml.jackson:jackson-bom:2.11.0"))
             add("implementation", platform("com.amazonaws:aws-java-sdk-bom:1.11.949"))
@@ -176,16 +171,6 @@ allprojects {
                     }
                 }
             }
-
-//            repositories {
-//                maven {
-//                    url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
-//                    credentials {
-//                        username = "${findProperty("aws.sonatype.username")}"
-//                        password = "${findProperty("aws.sonatype.password")}"
-//                    }
-//                }
-//            }
         }
 
         tasks.withType<Sign>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ val releaseTask = tasks.named("release")
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }
@@ -176,15 +176,15 @@ subprojects {
                 }
             }
 
-            repositories {
-                maven {
-                    url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                    credentials {
-                        username = "${findProperty("aws.sonatype.username")}"
-                        password = "${findProperty("aws.sonatype.password")}"
-                    }
-                }
-            }
+//            repositories {
+//                maven {
+//                    url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
+//                    credentials {
+//                        username = "${findProperty("aws.sonatype.username")}"
+//                        password = "${findProperty("aws.sonatype.password")}"
+//                    }
+//                }
+//            }
         }
 
         tasks.withType<Sign>().configureEach {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,13 @@
 rootProject.name = "com.amazonaws.xray.agent"
 
+pluginManagement {
+    plugins {
+        id("com.github.johnrengelman.shadow") version "5.2.0"
+        id("nebula.release") version "15.1.0"
+        id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
+    }
+}
+
 include("aws-xray-agent")
 include("aws-xray-agent-plugin")
 include("aws-xray-agent-benchmark")


### PR DESCRIPTION
*Description of changes:*
Adds an automated release workflow to trigger GitHub and Nexus releases from the repo. Heavily inspired by [this workflow](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/workflows/release-build.yml). You can see a "dry run" of the workflow on my fork [here](https://github.com/willarmiros/aws-xray-java-agent/runs/2347557187?check_suite_focus=true).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
