### PR TITLE
Fix jar naming and uncomment sql integ tests

### DIFF
--- a/aws-xray-agent-plugin/build.gradle.kts
+++ b/aws-xray-agent-plugin/build.gradle.kts
@@ -132,8 +132,9 @@ tasks {
         dependsOn("shadowJar")
         from("$buildDir/libs")
 
+        val regexSafeVersion: String = version.toString().replace("+", "\\+")
         include("aws-xray-agent-plugin-$version.jar")
-        rename("(.+)-$version(.+)", "$1$2")
+        rename("(.+)-$regexSafeVersion(.+)", "$1$2")
 
         into("$buildDir/libs/disco/disco-plugins")
     }

--- a/aws-xray-agent-plugin/build.gradle.kts
+++ b/aws-xray-agent-plugin/build.gradle.kts
@@ -150,7 +150,7 @@ tasks {
                 }
 
         // Integration tests run on Windows and Unix in GitHub actions
-        jvmArgs("-javaagent:$buildDir/libs/disco/disco-java-agent.jar=pluginPath=$buildDir/libs/disco/disco-plugins",
+        jvmArgs("-javaagent:$buildDir/libs/disco/disco-java-agent.jar=pluginPath=$buildDir/libs/disco/disco-plugins:loggerfactory=software.amazon.disco.agent.reflect.logging.StandardOutputLoggerFactory",
                 "-Dcom.amazonaws.xray.strategy.tracingName=IntegTest")
 
         // Cannot run tests until agent and all plugins are available

--- a/aws-xray-agent-plugin/src/test/java/com/amazonaws/xray/agent/runtime/handlers/downstream/SqlPrepareHandlerIntegTest.java
+++ b/aws-xray-agent-plugin/src/test/java/com/amazonaws/xray/agent/runtime/handlers/downstream/SqlPrepareHandlerIntegTest.java
@@ -1,79 +1,77 @@
-//package com.amazonaws.xray.agent.runtime.handlers.downstream;
-//
-//import com.amazonaws.xray.AWSXRay;
-//import com.amazonaws.xray.agent.runtime.handlers.downstream.source.sql.MyConnectionImpl;
-//import com.amazonaws.xray.entities.Subsegment;
-//import com.amazonaws.xray.sql.SqlSubsegments;
-//import org.junit.After;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//
-//import java.sql.CallableStatement;
-//import java.sql.Connection;
-//import java.sql.DatabaseMetaData;
-//import java.sql.PreparedStatement;
-//import java.sql.SQLException;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.Mockito.when;
-//
-//
-//// TODO: uncomment when https://github.com/aws/aws-xray-sdk-java/pull/270 and https://github.com/awslabs/disco/pull/16
-//// are released
-//public class SqlPrepareHandlerIntegTest {
-//    private static final String SQL = "SELECT * FROM my_table";
-//    private Connection connection;
-//
-//    @Mock
-//    private PreparedStatement preparedStatement;
-//
-//    @Mock
-//    private CallableStatement callableStatement;
-//
-//    @Mock
-//    private DatabaseMetaData mockMetadata;
-//
-//    @Before
-//    public void setup() throws SQLException {
-//        MockitoAnnotations.initMocks(this);
-//        connection = new MyConnectionImpl(preparedStatement, callableStatement, mockMetadata);
-//        when(preparedStatement.getConnection()).thenReturn(connection);
-//        when(preparedStatement.toString()).thenReturn(null);
-//        when(callableStatement.getConnection()).thenReturn(connection);
-//        when(callableStatement.toString()).thenReturn(null);
-//        when(mockMetadata.getURL()).thenReturn("http://example.com");
-//        when(mockMetadata.getUserName()).thenReturn("user");
-//        when(mockMetadata.getDriverVersion()).thenReturn("1.0");
-//        when(mockMetadata.getDatabaseProductName()).thenReturn("MySQL");
-//        when(mockMetadata.getDatabaseProductVersion()).thenReturn("2.0");
-//
-//        AWSXRay.beginSegment("test");
-//    }
-//
-//    @After
-//    public void cleanup() {
-//        AWSXRay.clearTraceEntity();
-//    }
-//
-//    @Test
-//    public void testPreparedStatementQueryCaptured() throws SQLException {
-//        connection.prepareStatement(SQL);  // insert into map
-//        preparedStatement.execute();
-//
-//        assertThat(AWSXRay.getCurrentSegment().getSubsegments()).hasSize(1);
-//        Subsegment sub = AWSXRay.getCurrentSegment().getSubsegments().get(0);
-//        assertThat(sub.getSql()).containsEntry(SqlSubsegments.SANITIZED_QUERY, SQL);
-//    }
-//
-//    @Test
-//    public void testCallableStatementQueryCaptured() throws SQLException {
-//        connection.prepareCall(SQL);  // insert into map
-//        callableStatement.execute();
-//
-//        assertThat(AWSXRay.getCurrentSegment().getSubsegments()).hasSize(1);
-//        Subsegment sub = AWSXRay.getCurrentSegment().getSubsegments().get(0);
-//        assertThat(sub.getSql()).containsEntry(SqlSubsegments.SANITIZED_QUERY, SQL);
-//    }
-//}
+package com.amazonaws.xray.agent.runtime.handlers.downstream;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.agent.runtime.handlers.downstream.source.sql.MyConnectionImpl;
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.sql.SqlSubsegments;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+public class SqlPrepareHandlerIntegTest {
+    private static final String SQL = "SELECT * FROM my_table";
+    private Connection connection;
+
+    @Mock
+    private PreparedStatement preparedStatement;
+
+    @Mock
+    private CallableStatement callableStatement;
+
+    @Mock
+    private DatabaseMetaData mockMetadata;
+
+    @Before
+    public void setup() throws SQLException {
+        MockitoAnnotations.initMocks(this);
+        connection = new MyConnectionImpl(preparedStatement, callableStatement, mockMetadata);
+        when(preparedStatement.getConnection()).thenReturn(connection);
+        when(preparedStatement.toString()).thenReturn(null);
+        when(callableStatement.getConnection()).thenReturn(connection);
+        when(callableStatement.toString()).thenReturn(null);
+        when(mockMetadata.getURL()).thenReturn("http://example.com");
+        when(mockMetadata.getUserName()).thenReturn("user");
+        when(mockMetadata.getDriverVersion()).thenReturn("1.0");
+        when(mockMetadata.getDatabaseProductName()).thenReturn("MySQL");
+        when(mockMetadata.getDatabaseProductVersion()).thenReturn("2.0");
+
+        AWSXRay.beginSegment("test");
+    }
+
+    @After
+    public void cleanup() {
+        AWSXRay.clearTraceEntity();
+    }
+
+    @Test
+    public void testPreparedStatementQueryCaptured() throws SQLException {
+        connection.prepareStatement(SQL);  // insert into map
+        preparedStatement.execute();
+
+        assertThat(AWSXRay.getCurrentSegment().getSubsegments()).hasSize(1);
+        Subsegment sub = AWSXRay.getCurrentSegment().getSubsegments().get(0);
+        assertThat(sub.getSql()).containsEntry(SqlSubsegments.SANITIZED_QUERY, SQL);
+    }
+
+    @Test
+    public void testCallableStatementQueryCaptured() throws SQLException {
+        connection.prepareCall(SQL);  // insert into map
+        callableStatement.execute();
+
+        assertThat(AWSXRay.getCurrentSegment().getSubsegments()).hasSize(1);
+        Subsegment sub = AWSXRay.getCurrentSegment().getSubsegments().get(0);
+        assertThat(sub.getSql()).containsEntry(SqlSubsegments.SANITIZED_QUERY, SQL);
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* Fix the naming logic for the X-Ray agent plugin to account for new generated names by the Nexus versioning plugin. The new dev versions can have `+`s in them which break the regex so we just escape them.
* Uncomment the integ tests originally introduced in #92, but that were dependent on 2.9.0 of the SDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
