### PR TITLE
Bump log4j to v2.15.0

### DIFF
--- a/aws-xray-agent/build.gradle.kts
+++ b/aws-xray-agent/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     // For reflective Trace ID injection tests
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-log4j")
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-slf4j")
-    testImplementation("org.apache.logging.log4j:log4j-api:2.13.3")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.15.0")
     testImplementation("ch.qos.logback:logback-classic:1.3.0-alpha5")
 }
 


### PR DESCRIPTION
Although this is a test dependency, we should still bump up the version to be free from the identified security vulnerability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
