### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/aws-xray-agent/build.gradle.kts
+++ b/aws-xray-agent/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     // For reflective Trace ID injection tests
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-log4j")
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-slf4j")
-    testImplementation("org.apache.logging.log4j:log4j-api:2.15.0")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.17.0")
     testImplementation("ch.qos.logback:logback-classic:1.3.0-alpha5")
 }
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
