### PR TITLE
preparing release v2.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.18.2 - 2025-02-26
+* Fixed a list of CVE violations [PR #123](https://github.com/aws/aws-xray-java-agent/pull/123)
+
 ## 2.9.1 - 2021-06-03
 * Updated dependencies to latest [PR #104](https://github.com/aws/aws-xray-java-agent/pull/104)
 

--- a/aws-xray-agent-benchmark/build.gradle.kts
+++ b/aws-xray-agent-benchmark/build.gradle.kts
@@ -1,8 +1,10 @@
+
 plugins {
-    id("me.champeau.gradle.jmh") version "0.5.0"
+    id("me.champeau.jmh") version "0.7.1"
 }
 
-val JMH_VERSION = "1.23"
+
+val JMH_VERSION = "1.37"
 
 sourceSets {
     named("jmh") {
@@ -63,7 +65,6 @@ jmh {
     }
 
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
-    isZip64 = true
 }
 
 // Need to have the disco directory assembled to run benchmarks with X-Ray agent
@@ -72,3 +73,11 @@ tasks.jmh {
         dependsOn(":aws-xray-agent-plugin:build")
     }
 }
+tasks.withType<Copy>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType<Jar>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+

--- a/aws-xray-agent-benchmark/results/2.18.x/jmh/auto-instrumentation.txt
+++ b/aws-xray-agent-benchmark/results/2.18.x/jmh/auto-instrumentation.txt
@@ -1,0 +1,51 @@
+Benchmark                                          Mode   Cnt  Score   Error   Units
+AwsSdkBenchmark.awsV1Request                      thrpt     5  0.409 ± 0.008  ops/ms
+AwsSdkBenchmark.awsV2Request                      thrpt     5  0.383 ± 0.052  ops/ms
+HttpDownstreamBenchmark.makeHttpRequest           thrpt     5  0.412 ± 0.009  ops/ms
+ServletBenchmark.serviceRequest                   thrpt     5  0.459 ± 0.002  ops/ms
+SqlBenchmark.sqlQuery                             thrpt     5  0.464 ± 0.024  ops/ms
+AwsSdkBenchmark.awsV1Request                     sample  2038  2.453 ± 0.007   ms/op
+AwsSdkBenchmark.awsV1Request:p0.00               sample        2.363           ms/op
+AwsSdkBenchmark.awsV1Request:p0.50               sample        2.441           ms/op
+AwsSdkBenchmark.awsV1Request:p0.90               sample        2.511           ms/op
+AwsSdkBenchmark.awsV1Request:p0.95               sample        2.560           ms/op
+AwsSdkBenchmark.awsV1Request:p0.99               sample        2.630           ms/op
+AwsSdkBenchmark.awsV1Request:p0.999              sample        3.001           ms/op
+AwsSdkBenchmark.awsV1Request:p0.9999             sample        6.406           ms/op
+AwsSdkBenchmark.awsV1Request:p1.00               sample        6.406           ms/op
+AwsSdkBenchmark.awsV2Request                     sample  1927  2.594 ± 0.008   ms/op
+AwsSdkBenchmark.awsV2Request:p0.00               sample        2.462           ms/op
+AwsSdkBenchmark.awsV2Request:p0.50               sample        2.556           ms/op
+AwsSdkBenchmark.awsV2Request:p0.90               sample        2.745           ms/op
+AwsSdkBenchmark.awsV2Request:p0.95               sample        2.793           ms/op
+AwsSdkBenchmark.awsV2Request:p0.99               sample        2.936           ms/op
+AwsSdkBenchmark.awsV2Request:p0.999              sample        3.334           ms/op
+AwsSdkBenchmark.awsV2Request:p0.9999             sample        3.805           ms/op
+AwsSdkBenchmark.awsV2Request:p1.00               sample        3.805           ms/op
+HttpDownstreamBenchmark.makeHttpRequest          sample  2063  2.424 ± 0.007   ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.00    sample        2.347           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.50    sample        2.413           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.90    sample        2.470           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.95    sample        2.494           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.99    sample        2.578           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.999   sample        2.857           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.9999  sample        6.488           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p1.00    sample        6.488           ms/op
+ServletBenchmark.serviceRequest                  sample  2294  2.179 ± 0.001   ms/op
+ServletBenchmark.serviceRequest:p0.00            sample        2.134           ms/op
+ServletBenchmark.serviceRequest:p0.50            sample        2.175           ms/op
+ServletBenchmark.serviceRequest:p0.90            sample        2.187           ms/op
+ServletBenchmark.serviceRequest:p0.95            sample        2.195           ms/op
+ServletBenchmark.serviceRequest:p0.99            sample        2.298           ms/op
+ServletBenchmark.serviceRequest:p0.999           sample        2.373           ms/op
+ServletBenchmark.serviceRequest:p0.9999          sample        2.380           ms/op
+ServletBenchmark.serviceRequest:p1.00            sample        2.380           ms/op
+SqlBenchmark.sqlQuery                            sample  2343  2.135 ± 0.001   ms/op
+SqlBenchmark.sqlQuery:p0.00                      sample        2.085           ms/op
+SqlBenchmark.sqlQuery:p0.50                      sample        2.130           ms/op
+SqlBenchmark.sqlQuery:p0.90                      sample        2.142           ms/op
+SqlBenchmark.sqlQuery:p0.95                      sample        2.178           ms/op
+SqlBenchmark.sqlQuery:p0.99                      sample        2.226           ms/op
+SqlBenchmark.sqlQuery:p0.999                     sample        2.292           ms/op
+SqlBenchmark.sqlQuery:p0.9999                    sample        2.482           ms/op
+SqlBenchmark.sqlQuery:p1.00                      sample        2.482           ms/op

--- a/aws-xray-agent-benchmark/results/2.18.x/jmh/no-instrumentation.txt
+++ b/aws-xray-agent-benchmark/results/2.18.x/jmh/no-instrumentation.txt
@@ -1,0 +1,51 @@
+Benchmark                                          Mode   Cnt   Score    Error   Units
+AwsSdkBenchmark.awsV1Request                      thrpt     5   0.420 ±  0.008  ops/ms
+AwsSdkBenchmark.awsV2Request                      thrpt     5   0.405 ±  0.026  ops/ms
+HttpDownstreamBenchmark.makeHttpRequest           thrpt     5   0.420 ±  0.010  ops/ms
+ServletBenchmark.serviceRequest                   thrpt     5   0.483 ±  0.001  ops/ms
+SqlBenchmark.sqlQuery                             thrpt     5   0.484 ±  0.002  ops/ms
+AwsSdkBenchmark.awsV1Request                     sample  2096   2.385 ±  0.012   ms/op
+AwsSdkBenchmark.awsV1Request:p0.00               sample         2.302            ms/op
+AwsSdkBenchmark.awsV1Request:p0.50               sample         2.372            ms/op
+AwsSdkBenchmark.awsV1Request:p0.90               sample         2.425            ms/op
+AwsSdkBenchmark.awsV1Request:p0.95               sample         2.466            ms/op
+AwsSdkBenchmark.awsV1Request:p0.99               sample         2.540            ms/op
+AwsSdkBenchmark.awsV1Request:p0.999              sample         6.357            ms/op
+AwsSdkBenchmark.awsV1Request:p0.9999             sample         8.086            ms/op
+AwsSdkBenchmark.awsV1Request:p1.00               sample         8.086            ms/op
+AwsSdkBenchmark.awsV2Request                     sample  2026   2.468 ±  0.012   ms/op
+AwsSdkBenchmark.awsV2Request:p0.00               sample         2.380            ms/op
+AwsSdkBenchmark.awsV2Request:p0.50               sample         2.449            ms/op
+AwsSdkBenchmark.awsV2Request:p0.90               sample         2.523            ms/op
+AwsSdkBenchmark.awsV2Request:p0.95               sample         2.568            ms/op
+AwsSdkBenchmark.awsV2Request:p0.99               sample         2.691            ms/op
+AwsSdkBenchmark.awsV2Request:p0.999              sample         3.407            ms/op
+AwsSdkBenchmark.awsV2Request:p0.9999             sample         9.552            ms/op
+AwsSdkBenchmark.awsV2Request:p1.00               sample         9.552            ms/op
+HttpDownstreamBenchmark.makeHttpRequest          sample  2057   2.430 ±  0.022   ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.00    sample         2.351            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.50    sample         2.404            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.90    sample         2.458            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.95    sample         2.515            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.99    sample         2.771            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.999   sample        11.164            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.9999  sample        11.846            ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p1.00    sample        11.846            ms/op
+ServletBenchmark.serviceRequest                  sample  2416   2.070 ±  0.001   ms/op
+ServletBenchmark.serviceRequest:p0.00            sample         2.025            ms/op
+ServletBenchmark.serviceRequest:p0.50            sample         2.068            ms/op
+ServletBenchmark.serviceRequest:p0.90            sample         2.073            ms/op
+ServletBenchmark.serviceRequest:p0.95            sample         2.079            ms/op
+ServletBenchmark.serviceRequest:p0.99            sample         2.105            ms/op
+ServletBenchmark.serviceRequest:p0.999           sample         2.126            ms/op
+ServletBenchmark.serviceRequest:p0.9999          sample         2.363            ms/op
+ServletBenchmark.serviceRequest:p1.00            sample         2.363            ms/op
+SqlBenchmark.sqlQuery                            sample  2424   2.064 ±  0.001   ms/op
+SqlBenchmark.sqlQuery:p0.00                      sample         2.023            ms/op
+SqlBenchmark.sqlQuery:p0.50                      sample         2.062            ms/op
+SqlBenchmark.sqlQuery:p0.90                      sample         2.068            ms/op
+SqlBenchmark.sqlQuery:p0.95                      sample         2.075            ms/op
+SqlBenchmark.sqlQuery:p0.99                      sample         2.091            ms/op
+SqlBenchmark.sqlQuery:p0.999                     sample         2.118            ms/op
+SqlBenchmark.sqlQuery:p0.9999                    sample         2.183            ms/op
+SqlBenchmark.sqlQuery:p1.00                      sample         2.183            ms/op

--- a/aws-xray-agent-benchmark/results/2.18.x/jmh/sdk-instrumentation.txt
+++ b/aws-xray-agent-benchmark/results/2.18.x/jmh/sdk-instrumentation.txt
@@ -1,0 +1,51 @@
+Benchmark                                          Mode   Cnt   Score   Error   Units
+AwsSdkBenchmark.awsV1Request                      thrpt     5   0.413 ± 0.009  ops/ms
+AwsSdkBenchmark.awsV2Request                      thrpt     5   0.392 ± 0.085  ops/ms
+HttpDownstreamBenchmark.makeHttpRequest           thrpt     5   0.416 ± 0.007  ops/ms
+ServletBenchmark.serviceRequest                   thrpt     5   0.462 ± 0.012  ops/ms
+SqlBenchmark.sqlQuery                             thrpt     5   0.465 ± 0.022  ops/ms
+AwsSdkBenchmark.awsV1Request                     sample  2072   2.412 ± 0.010   ms/op
+AwsSdkBenchmark.awsV1Request:p0.00               sample         2.314           ms/op
+AwsSdkBenchmark.awsV1Request:p0.50               sample         2.404           ms/op
+AwsSdkBenchmark.awsV1Request:p0.90               sample         2.465           ms/op
+AwsSdkBenchmark.awsV1Request:p0.95               sample         2.504           ms/op
+AwsSdkBenchmark.awsV1Request:p0.99               sample         2.562           ms/op
+AwsSdkBenchmark.awsV1Request:p0.999              sample         2.739           ms/op
+AwsSdkBenchmark.awsV1Request:p0.9999             sample         8.331           ms/op
+AwsSdkBenchmark.awsV1Request:p1.00               sample         8.331           ms/op
+AwsSdkBenchmark.awsV2Request                     sample  1975   2.532 ± 0.086   ms/op
+AwsSdkBenchmark.awsV2Request:p0.00               sample         2.413           ms/op
+AwsSdkBenchmark.awsV2Request:p0.50               sample         2.486           ms/op
+AwsSdkBenchmark.awsV2Request:p0.90               sample         2.589           ms/op
+AwsSdkBenchmark.awsV2Request:p0.95               sample         2.634           ms/op
+AwsSdkBenchmark.awsV2Request:p0.99               sample         2.819           ms/op
+AwsSdkBenchmark.awsV2Request:p0.999              sample         5.522           ms/op
+AwsSdkBenchmark.awsV2Request:p0.9999             sample        53.871           ms/op
+AwsSdkBenchmark.awsV2Request:p1.00               sample        53.871           ms/op
+HttpDownstreamBenchmark.makeHttpRequest          sample  2088   2.394 ± 0.018   ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.00    sample         2.322           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.50    sample         2.380           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.90    sample         2.421           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.95    sample         2.437           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.99    sample         2.544           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.999   sample         9.448           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p0.9999  sample        10.420           ms/op
+HttpDownstreamBenchmark.makeHttpRequest:p1.00    sample        10.420           ms/op
+ServletBenchmark.serviceRequest                  sample  2309   2.166 ± 0.002   ms/op
+ServletBenchmark.serviceRequest:p0.00            sample         2.126           ms/op
+ServletBenchmark.serviceRequest:p0.50            sample         2.154           ms/op
+ServletBenchmark.serviceRequest:p0.90            sample         2.208           ms/op
+ServletBenchmark.serviceRequest:p0.95            sample         2.232           ms/op
+ServletBenchmark.serviceRequest:p0.99            sample         2.273           ms/op
+ServletBenchmark.serviceRequest:p0.999           sample         2.326           ms/op
+ServletBenchmark.serviceRequest:p0.9999          sample         2.331           ms/op
+ServletBenchmark.serviceRequest:p1.00            sample         2.331           ms/op
+SqlBenchmark.sqlQuery                            sample  2333   2.143 ± 0.029   ms/op
+SqlBenchmark.sqlQuery:p0.00                      sample         2.085           ms/op
+SqlBenchmark.sqlQuery:p0.50                      sample         2.126           ms/op
+SqlBenchmark.sqlQuery:p0.90                      sample         2.159           ms/op
+SqlBenchmark.sqlQuery:p0.95                      sample         2.191           ms/op
+SqlBenchmark.sqlQuery:p0.99                      sample         2.236           ms/op
+SqlBenchmark.sqlQuery:p0.999                     sample         2.280           ms/op
+SqlBenchmark.sqlQuery:p0.9999                    sample        22.610           ms/op
+SqlBenchmark.sqlQuery:p1.00                      sample        22.610           ms/op

--- a/aws-xray-agent/build.gradle.kts
+++ b/aws-xray-agent/build.gradle.kts
@@ -45,7 +45,7 @@ jacoco {
 }
 tasks.jacocoTestReport {
     reports {
-        xml.required = true
-        html.required = true
+	html.required.set(true)
+	xml.required.set(true)
     }
 }


### PR DESCRIPTION
*Description of changes:*
Added benchmark 2.18.2 results and bump the dependency version for V2.18.2 release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
