### PR TITLE
fix(daily-scan): scan published artifacts instead of repo source

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -59,6 +59,11 @@ jobs:
           # Download the released JAR from Maven Central
           wget https://repo.maven.apache.org/maven2/com/amazonaws/aws-xray-agent-plugin/$version/aws-xray-agent-plugin-$version.jar
           
+          # Copy JAR to scan-target/ for DependencyCheck — DC detects shaded
+          # dependencies via META-INF/maven/*/pom.xml inside the JAR archive.
+          mkdir -p scan-target
+          cp aws-xray-agent-plugin-$version.jar scan-target/
+          
           # Extract JAR contents for Trivy scanning
           mkdir -p released-artifact
           cd released-artifact
@@ -75,7 +80,7 @@ jobs:
           curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
           gpg --verify dependency-check.zip.asc
           unzip dependency-check.zip
-          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "."
+          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "scan-target/"
 
       - name: Print dependency scan results on failure
         if: ${{ steps.dep_scan.outcome != 'success' }}


### PR DESCRIPTION
## Problem

DependencyCheck (DC) scans `-s "."` which includes DC's own bundled jars in `./dependency-check/lib/`, producing false positive CVEs (commons-beanutils, h2, logback, gson, httpclient5, etc.).

Additionally, scanning source code means if a vulnerability exists in the published artifact but has already been fixed on `main`, the scan gives a false negative — customers are still exposed.

## Fix

Instead of scanning the repo source tree, download/install the **published artifact** from its package registry into a dedicated `scan-target/` directory, then scan only that.

This pattern is already proven by ADOT Java and ADOT Python repos.

## Changes

- Replace the pre-scan build/install step with one that fetches the published artifact into `scan-target/`
- Change the DC scan target from `-s "."` to `-s "scan-target/"`
- All other steps (checkout, DC download/GPG/unzip, Trivy, metrics) are unchanged
- All DC flags (`--failOnCVSS 0`, `--enableExperimental`, `--nvdApiKey`, etc.) are unchanged

## Testing

Tested locally with DC v12.1.0 against NVD database. Verified:
- All reported dependencies come from the published artifact
- Zero DC tool jars in the report (no false positives)
- Dependency count matches expected published artifact contents