### PR TITLE
Fix Sonatype publishing URL for OSSRH sunset

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,8 @@ val releaseTask = tasks.named("release")
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }


### PR DESCRIPTION
## Summary
With EOL of Sonatype OSSRH, update publishing URLs to Sonatype Central as per https://central.sonatype.org/news/20250326_ossrh_sunset/

Same change as https://github.com/aws/aws-xray-sdk-java/pull/426