### PR TITLE
Update dependencies ahead of 2.21.1 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val discoVersion by extra("0.13.0")
 val xraySdkVersion by extra("2.21.0")
 val awsSdkV1Version by extra("1.12.797")
-val awsSdkV2Version by extra("2.42.31")
+val awsSdkV2Version by extra("2.48.0")
 
 val releaseTask = tasks.named("release")
 


### PR DESCRIPTION
## Description
Updates the AWS SDK v2 BOM from 2.42.31 to 2.48.0, per the dependency-update preflight step of release MCM for v2.21.1.

Other pinned versions are already at their latest:
- `discoVersion` 0.13.0 (latest `software.amazon.disco:disco-toolkit-bom`)
- `xraySdkVersion` 2.21.0 (latest `com.amazonaws:aws-xray-recorder-sdk-bom`)
- `awsSdkV1Version` 1.12.797 (latest `com.amazonaws:aws-java-sdk-bom`)

Verified with `./gradlew build` (JDK 11) — all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)