### PR TITLE
Prepares Release 2.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.21.1 - 2026-07-15
+* Updated Jackson BOM from 2.18.6 to 2.18.8 to address CVE-2026-54512 and CVE-2026-54513 [PR #142](https://github.com/aws/aws-xray-java-agent/pull/142)
+* Updated AWS SDK v2 from 2.42.31 to 2.48.0 [PR #143](https://github.com/aws/aws-xray-java-agent/pull/143)
+
 ## 2.21.0 - 2026-04-09
 * Updated X-Ray SDK from 2.18.2 to 2.21.0
 * Updated AWS SDK v1 from 1.12.708 to 1.12.797

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To depend on the agent from your project, just add these dependencies:
     <dependency>
         <groupId>software.amazon.disco</groupId>
         <artifactId>disco-toolkit-bom</artifactId>
-        <version>0.11.0</version>
+        <version>0.13.0</version>
         <type>pom</type>
         <scope>import</scope>
     </dependency>
@@ -79,7 +79,7 @@ To depend on the agent from your project, just add these dependencies:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-xray-agent-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>2.21.1</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val discoVersion by extra("0.13.0")
 val xraySdkVersion by extra("2.21.0")
 val awsSdkV1Version by extra("1.12.797")
-val awsSdkV2Version by extra("2.42.31")
+val awsSdkV2Version by extra("2.48.0")
 
 val releaseTask = tasks.named("release")
 


### PR DESCRIPTION
## Description
Prepares the v2.21.1 release:
- Adds 2.21.1 entry to `CHANGELOG.md` (Jackson BOM 2.18.6 → 2.18.8 for CVE-2026-54512/CVE-2026-54513, AWS SDK v2 2.42.31 → 2.48.0)
- Updates `README.md` installation instructions to agent version 2.21.1 and Disco BOM 0.13.0

Part of release MCM-154610213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)